### PR TITLE
Bump cf-networking-helpers dependency for MySQL8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+/pkg
+/bin
+bin

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace github.com/square/certstrap => github.com/square/certstrap v1.1.1
 
 require (
 	code.cloudfoundry.org/bbs v0.0.0-20210727125654-2ad50317f7ed // indirect
-	code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210825141236-777da71209d5
+	code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210929193536-efcc04207348
 	code.cloudfoundry.org/debugserver v0.0.0-20210608171006-d7658ce493f4
 	code.cloudfoundry.org/filelock v0.0.0-20180314203404-13cd41364639
 	code.cloudfoundry.org/lager v2.0.0+incompatible
@@ -40,6 +40,7 @@ require (
 	github.com/vishvananda/netlink v1.1.0
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	github.com/ziutek/utils v0.0.0-20190626152656-eb2a3b364d6c
+	google.golang.org/appengine v1.3.0 // indirect
 	gopkg.in/validator.v2 v2.0.0-20210331031555-b37d688a7fb0
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ code.cloudfoundry.org/bbs v0.0.0-20210727125654-2ad50317f7ed h1:lXyKwHvjX8AofvDk
 code.cloudfoundry.org/bbs v0.0.0-20210727125654-2ad50317f7ed/go.mod h1:XKlGVVXFi5EcHHMPzw3xgONK9PeEZuUbIC43XNwxD10=
 code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210825141236-777da71209d5 h1:2LNoWK64q5eJjFK1be1HoNeWh0tFZ4nGIz4YJmDvn00=
 code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210825141236-777da71209d5/go.mod h1:kf4WVsGZqWT4r9wA9xLpdc4U/QtB5HcUUMa1VSsb6AM=
+code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210929193536-efcc04207348 h1:6J54855savU7Iey5LA9AaevzV5JMnSCLR21piSeVjhw=
+code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210929193536-efcc04207348/go.mod h1:/3sxa/kc03LJnMR688nN/v1N7VDNzCbICOaNDdvS37s=
 code.cloudfoundry.org/debugserver v0.0.0-20210608171006-d7658ce493f4 h1:6UIZEq5iyr4zDCgOH5MtRbgvsIjk4XFNUaaoMekEssQ=
 code.cloudfoundry.org/debugserver v0.0.0-20210608171006-d7658ce493f4/go.mod h1:gNKNma2dj1tNTqiguITu8zzSyfGPPavqckoGXQxdnsI=
 code.cloudfoundry.org/filelock v0.0.0-20180314203404-13cd41364639 h1:c+Sv3PcX6x3oaZmgznhYqrfkBX1Sjx511Sr9eHjMyQk=
@@ -192,6 +194,7 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pivotal-cf-experimental/gomegamatchers v0.0.0-20180326192815-e36bfcc98c3a h1:K20a2viyp6kZgY41ESLne0eOXyY9DarmwA4q6zQ686w=
 github.com/pivotal-cf-experimental/gomegamatchers v0.0.0-20180326192815-e36bfcc98c3a/go.mod h1:HdFegZwXOoRNyrqaOX6FC1zMkbA2k1/ktb2anj1E0K8=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/vendor/code.cloudfoundry.org/cf-networking-helpers/db/connection_pool.go
+++ b/vendor/code.cloudfoundry.org/cf-networking-helpers/db/connection_pool.go
@@ -31,7 +31,7 @@ func NewConnectionPool(conf Config,
 	connectionPool.SetMaxOpenConns(maxOpenConnections)
 	connectionPool.SetMaxIdleConns(maxIdleConnections)
 	connectionPool.SetConnMaxLifetime(connMaxLifetime)
-	logger.Info("db connection retrived", lager.Data{})
+	logger.Info("db connection retrieved", lager.Data{})
 
 	return connectionPool, nil
 }

--- a/vendor/code.cloudfoundry.org/cf-networking-helpers/db/mysql_connection_string_builder.go
+++ b/vendor/code.cloudfoundry.org/cf-networking-helpers/db/mysql_connection_string_builder.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
@@ -21,7 +22,8 @@ type MySQLConnectionStringBuilder struct {
 }
 
 func (m *MySQLConnectionStringBuilder) Build(config Config) (string, error) {
-	connString := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true", config.User, config.Password, config.Host, config.Port, config.DatabaseName)
+	sqlMode := url.QueryEscape("(SELECT CONCAT(@@sql_mode,',ANSI_QUOTES'))")
+	connString := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true&sql_mode=%s", config.User, config.Password, config.Host, config.Port, config.DatabaseName, sqlMode)
 
 	dbConfig, err := m.MySQLAdapter.ParseDSN(connString)
 	if err != nil {

--- a/vendor/code.cloudfoundry.org/cf-networking-helpers/testsupport/db.go
+++ b/vendor/code.cloudfoundry.org/cf-networking-helpers/testsupport/db.go
@@ -122,8 +122,6 @@ func getMySQLDBConfig() db.Config {
 	}
 	port, _ := strconv.Atoi(portStr)
 
-	fmt.Printf("User %s , Password %s , host %s , port %d\n", user, password, host, port)
-
 	return db.Config{
 		Type:     "mysql",
 		User:     user,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # code.cloudfoundry.org/bbs v0.0.0-20210727125654-2ad50317f7ed
 ## explicit
 code.cloudfoundry.org/bbs/db/sqldb/helpers/monitor
-# code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210825141236-777da71209d5
+# code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210929193536-efcc04207348
 ## explicit
 code.cloudfoundry.org/cf-networking-helpers/db
 code.cloudfoundry.org/cf-networking-helpers/fakes
@@ -225,6 +225,8 @@ golang.org/x/text/runes
 golang.org/x/text/transform
 # golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e
 golang.org/x/tools/go/ast/inspector
+# google.golang.org/appengine v1.3.0
+## explicit
 # gopkg.in/gorp.v1 v1.7.2
 gopkg.in/gorp.v1
 # gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7


### PR DESCRIPTION
- Bump cf-networking-helpers to add ANSI_QUOTES to the sql_mode for new
  connections so that we can use the same quoting syntax for both MySQL
  and PostgreSQL

[#179730622](https://www.pivotaltracker.com/story/show/179730622)

cc/ @acrmp @cphi-vmw 