### PR TITLE
Fix silk-vtep interface creation for Ubuntu/Jammy

### DIFF
--- a/client/config/config.go
+++ b/client/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	ClientTimeoutSeconds      int    `json:"client_timeout_seconds" validate:"nonzero"`
 	MetronPort                int    `json:"metron_port" validate:"min=1"`
 	LogPrefix                 string `json:"log_prefix" validate:"nonzero"`
+	LogLevel                  string `json:"log_level"`
 	SingleIPOnly              bool   `json:"single_ip_only"`
 }
 

--- a/cmd/silk-daemon/main.go
+++ b/cmd/silk-daemon/main.go
@@ -60,8 +60,12 @@ func mainWithError() error {
 	if cfg.LogPrefix != "" {
 		logPrefix = cfg.LogPrefix
 	}
+	logLevel := lager.INFO.String()
+	if cfg.LogLevel != "" {
+		logLevel = cfg.LogLevel
+	}
 
-	logger, reconfigurableSink := lagerflags.NewFromConfig(fmt.Sprintf("%s.%s", logPrefix, jobPrefix), getLagerConfig())
+	logger, reconfigurableSink := lagerflags.NewFromConfig(fmt.Sprintf("%s.%s", logPrefix, jobPrefix), getLagerConfig(logLevel))
 	logger.Info("starting")
 
 	tlsConfig, err := mutualtls.NewClientTLSConfig(cfg.ClientCertFile, cfg.ClientKeyFile, cfg.ServerCACertFile)
@@ -87,6 +91,7 @@ func mainWithError() error {
 
 	vtepFactory := &vtep.Factory{
 		NetlinkAdapter: &adapter.NetlinkAdapter{},
+		Logger:         logger,
 	}
 	vtepConfigCreator := &vtep.ConfigCreator{
 		NetAdapter: &adapter.NetAdapter{},
@@ -304,8 +309,9 @@ func deleteAndAcquire(cfg config.Config, logger lager.Logger, client *controller
 	return acquireLease(logger, client, vtepConfigCreator, vtepFactory, cfg)
 }
 
-func getLagerConfig() lagerflags.LagerConfig {
+func getLagerConfig(level string) lagerflags.LagerConfig {
 	lagerConfig := lagerflags.DefaultLagerConfig()
 	lagerConfig.TimeFormat = lagerflags.FormatRFC3339
+	lagerConfig.LogLevel = level
 	return lagerConfig
 }

--- a/daemon/integration/integration_test.go
+++ b/daemon/integration/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"code.cloudfoundry.org/cf-networking-helpers/mutualtls"
 	"code.cloudfoundry.org/cf-networking-helpers/testsupport/metrics"
 	"code.cloudfoundry.org/cf-networking-helpers/testsupport/ports"
+	"code.cloudfoundry.org/lager/lagertest"
 	"code.cloudfoundry.org/silk/client/config"
 	"code.cloudfoundry.org/silk/controller"
 	"code.cloudfoundry.org/silk/daemon"
@@ -115,7 +116,7 @@ var _ = BeforeEach(func() {
 		LogPrefix:                 "potato-prefix",
 	}
 
-	vtepFactory = &vtep.Factory{&adapter.NetlinkAdapter{}}
+	vtepFactory = &vtep.Factory{&adapter.NetlinkAdapter{}, lagertest.NewTestLogger("test")}
 
 	serverTLSConfig, err = mutualtls.NewServerTLSConfig(paths.ServerCertFile, paths.ServerKeyFile, paths.ClientCACertFile)
 	Expect(err).NotTo(HaveOccurred())

--- a/daemon/vtep/factory.go
+++ b/daemon/vtep/factory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 
+	"code.cloudfoundry.org/lager"
 	"github.com/vishvananda/netlink"
 )
 
@@ -30,6 +31,7 @@ type netlinkAdapter interface {
 
 type Factory struct {
 	NetlinkAdapter netlinkAdapter
+	Logger         lager.Logger
 }
 
 func (f *Factory) CreateVTEP(cfg *Config) error {

--- a/daemon/vtep/factory_test.go
+++ b/daemon/vtep/factory_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 
+	"code.cloudfoundry.org/lager/lagertest"
 	"code.cloudfoundry.org/silk/daemon/vtep"
 	"code.cloudfoundry.org/silk/daemon/vtep/fakes"
 
@@ -17,12 +18,15 @@ var _ = Describe("Factory", func() {
 		fakeNetlinkAdapter *fakes.NetlinkAdapter
 		factory            *vtep.Factory
 		vtepConfig         *vtep.Config
+		fakeLogger         *lagertest.TestLogger
 	)
 
 	BeforeEach(func() {
 		fakeNetlinkAdapter = &fakes.NetlinkAdapter{}
+		fakeLogger = lagertest.NewTestLogger("test")
 		factory = &vtep.Factory{
 			NetlinkAdapter: fakeNetlinkAdapter,
+			Logger:         fakeLogger,
 		}
 
 		underlayInterface := net.Interface{

--- a/teardown/integration/integration_test.go
+++ b/teardown/integration/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 
 	"code.cloudfoundry.org/cf-networking-helpers/mutualtls"
+	"code.cloudfoundry.org/lager/lagertest"
 	"code.cloudfoundry.org/silk/client/config"
 	"code.cloudfoundry.org/silk/controller"
 	"code.cloudfoundry.org/silk/daemon/vtep"
@@ -55,7 +56,7 @@ var _ = BeforeEach(func() {
 		ClientCertFile:            paths.ClientCertFile,
 		ClientKeyFile:             paths.ClientKeyFile,
 		VNI:                       GinkgoParallelProcess(),
-		PollInterval:              5,                    // unused by teardown
+		PollInterval:              5,                       // unused by teardown
 		DebugServerPort:           GinkgoParallelProcess(), // unused by teardown
 		Datastore:                 datastoreFile.Name(),
 		PartitionToleranceSeconds: 60,    // unused by teardown
@@ -69,7 +70,7 @@ var _ = BeforeEach(func() {
 	Expect(err).NotTo(HaveOccurred())
 	fakeServer = testsupport.StartServer(serverListenAddr, serverTLSConfig)
 
-	vtepFactory = &vtep.Factory{NetlinkAdapter: &adapter.NetlinkAdapter{}}
+	vtepFactory = &vtep.Factory{NetlinkAdapter: &adapter.NetlinkAdapter{}, Logger: lagertest.NewTestLogger("test")}
 
 	Expect(vtepFactory.CreateVTEP(vtepConfig)).To(Succeed())
 


### PR DESCRIPTION
    Starting with Ubuntu 22.04 (jammy), we encountered cases where interfaces were
    not actually getting the hardware addr being set when we called LinkSetHardwareAddr below.

    https://wiki.archlinux.org/title/Systemd-networkd#%5BLink%5D  includes the following tip
    which is likely what's occurring:

    > Tip: systemd-networkd assigns a MAC address generated based on the interface name and
    > the machine ID to the bridge. This may cause connection issues, for example in case of
    > routing based on MAC filtering. To circumvent such problems you may assign a MAC address
    > to your bridge, probably the same as your physical device, adding the line
    > MACAddress=xx:xx:xx:xx:xx:xx in the NetDev section above.

    So, to workaround this, we're now setting HardwareAddr upon link creation.
    
    This also adds a commit for allowing operators to set log levels prior to starting silk-daemon (in case debugging is needed during process start/initialization)
